### PR TITLE
Fixes for differentiability

### DIFF
--- a/src/Duckietown.jl
+++ b/src/Duckietown.jl
@@ -5,6 +5,7 @@ using Space
 using Distributions
 using Random
 using RayTracer
+using Zygote
 
 include("utils.jl")
 

--- a/src/fixed_params.jl
+++ b/src/fixed_params.jl
@@ -1,4 +1,4 @@
-mutable struct FixedSimParams
+mutable struct FixedSimParams <: RayTracer.FixedParams
     rng::MersenneTwister
     _map::Map
     max_steps::Int              # Maximum number of steps per episode

--- a/src/graphics.jl
+++ b/src/graphics.jl
@@ -246,7 +246,7 @@ function bezier_tangent(cps, t)
     p += 6(1-t) * t * (cps[3,:] - cps[2,:])
     p += 3(t^2) * (cps[4,:] - cps[3,:])
 
-    p ./= norm(p)
+    p = p ./ norm(p)
 
     return p
 end

--- a/src/simulator.jl
+++ b/src/simulator.jl
@@ -1,4 +1,4 @@
-using RayTracer: FixedParams
+using RayTracer: FixedParams, @diffops
 
 struct DoneRewardInfo
     done::Bool
@@ -122,6 +122,8 @@ mutable struct Simulator
     timestamp::Float32
     fixedparams::FixedSimParams
 end
+
+@diffops Simulator
 
 function Simulator(
         map_name::String=DEFAULT_MAP_NAME,
@@ -661,6 +663,8 @@ function get_agent_info(sim::Simulator)
     misc["Simulator"] = info
     return misc
 end
+
+Zygote.@nograd get_agent_info
 
 #=
 function cartesian_from_weird(sim::Simulator, pos, angle)

--- a/src/simulator.jl
+++ b/src/simulator.jl
@@ -1,4 +1,5 @@
 using RayTracer: FixedParams, @diffops
+import Base: +, *, -
 
 struct DoneRewardInfo
     done::Bool

--- a/src/simulator.jl
+++ b/src/simulator.jl
@@ -907,7 +907,10 @@ function _render_img(fp::FixedSimParams, cur_pos, cur_angle, top_down=true)
     end
 
     # For each object
-    scene = vcat(scene, map(obj->render(obj, fp.draw_bbox), _objects(fp))...)
+    objs = _objects(fp)
+    if length(objs) > 0
+        scene = vcat(scene, map(obj->render(obj, fp.draw_bbox), _objects(fp))...)
+    end
 
     # Draw the agent's own bounding box
     if fp.draw_bbox


### PR DESCRIPTION
* Adds @nograd for `get_agent_info` function
* Makes `FixedSimParams` a subtype of `FixedParams` to avoid redefining
all the basic operations.
* Applied @diffop macro to `Simulator`
* Bypass Zygote differentiability errors